### PR TITLE
「ellipted」オプションの追加とコールバックの引数に元テキストを追加

### DIFF
--- a/src/jquery.ellipsis.js
+++ b/src/jquery.ellipsis.js
@@ -6,8 +6,9 @@
             'row' : 1, // show rows
             'onlyFullWords': false, // set to true to avoid cutting the text in the middle of a word
             'char' : '...', // ellipsis
-            'callback': function() {},
-            'position': 'tail' // middle, tail
+            'callback': function(_elem,_originalText) {},
+            'position': 'tail', // middle, tail
+            'ellipted': 'ellipted' // a class which will be added when the element has been elliped
         };
 
         options = $.extend(defaults, options);
@@ -29,7 +30,7 @@
 
             if (origHeight <= targetHeight) {
                 $this.text(text);
-                options.callback.call(this);
+                options.callback.call(this,origText);
                 return;
             }
 
@@ -88,9 +89,9 @@
                 text = head + options['char'] + tail;
             }
 
-            $this.text(text);
+            $this.text(text).addClass(options.ellipted);
 
-            options.callback.call(this);
+            options.callback.call(this,origText);
         });
 
         return this;

--- a/src/jquery.ellipsis.js
+++ b/src/jquery.ellipsis.js
@@ -16,7 +16,8 @@
         this.each(function() {
             // get element text
             var $this = $(this);
-            var text = $this.text();
+            var text = $(this).attr('data-originalText') || $this.text();
+            $this.text(text);
             var origText = text;
             var origLength = origText.length;
             var origHeight = $this.height();
@@ -89,7 +90,7 @@
                 text = head + options['char'] + tail;
             }
 
-            $this.text(text).addClass(options.ellipted);
+            $this.text(text).addClass(options.ellipted).attr('data-originalText',origText);
 
             options.callback.call(this,origText);
         });

--- a/src/jquery.ellipsis.js
+++ b/src/jquery.ellipsis.js
@@ -6,7 +6,7 @@
             'row' : 1, // show rows
             'onlyFullWords': false, // set to true to avoid cutting the text in the middle of a word
             'char' : '...', // ellipsis
-            'callback': function(_elem,_originalText) {},
+            'callback': function(_originalText) {},
             'position': 'tail', // middle, tail
             'ellipted': 'ellipted' // a class which will be added when the element has been elliped
         };


### PR DESCRIPTION
短縮を試みてそれが実際に行われたかどうかを示すクラスとして、「ellipted」オプションを追加。
また、コールバックに引き渡される引数が変更後の HTML 要素のみで、元テキストをベースにした処理ができないため、コールバックに元テキスト引き渡すようにした。
